### PR TITLE
increase lease timeout for tasks

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -56,7 +56,7 @@ function taskRunnerFactory(
         this.subscriptions = [];
         this.running = false;
         this.activeTasks = {};
-        this.lostBeatLimit = options.lostBeatLimit || 3;
+        this.lostBeatLimit = options.lostBeatLimit || 10;
         this.domain = options.domain || Constants.Task.DefaultDomain;
     }
 


### PR DESCRIPTION
Increasing the task lease timeout to address creation of zombie tasks when doing big discoveries.