### PR TITLE
Include node id in options payload

### DIFF
--- a/lib/graphs/persist-poller-data-graph.js
+++ b/lib/graphs/persist-poller-data-graph.js
@@ -8,6 +8,7 @@ module.exports = {
     options: {
     	defaults: {
     	    pollerId: null,
+    	    nodeId: null,
     	    interval: null,
     	    duration: null,
     	    catalogName: null,


### PR DESCRIPTION
Moving node id to payload so this graph can be run against /api/2.0/workflows endpoint.